### PR TITLE
Add support for mixed ? and $ placeholders

### DIFF
--- a/placeholder.go
+++ b/placeholder.go
@@ -3,6 +3,7 @@ package sqrl
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -34,6 +35,13 @@ type dollarFormat struct{}
 
 func (_ dollarFormat) ReplacePlaceholders(sql string) (string, error) {
 	return replacePlaceholders(sql, func(buf *bytes.Buffer, i int) error {
+		fmt.Fprintf(buf, "$%d", i)
+		return nil
+	})
+}
+
+func (_ dollarFormat) ReplacePlaceholdersMixed(sql string, args []interface{}) (string, []interface{}, error) {
+	return replacePlaceholdersMixed(sql, args, func(buf *bytes.Buffer, i int) error {
 		fmt.Fprintf(buf, "$%d", i)
 		return nil
 	})
@@ -76,4 +84,83 @@ func replacePlaceholders(sql string, replace func(buf *bytes.Buffer, i int) erro
 
 	buf.WriteString(sql)
 	return buf.String(), nil
+}
+
+func replacePlaceholdersMixed(
+	sql string, args []interface{}, replace func(buf *bytes.Buffer, i int) error,
+) (string, []interface{}, error) {
+	buf := &bytes.Buffer{}
+	i := 0
+	newArgs := make([]interface{}, 0, len(args))
+	arg := 0
+	var renumbered map[int]int
+	for {
+		p := strings.IndexAny(sql, "?$")
+		if p == -1 {
+			break
+		}
+
+		switch {
+		case len(sql[p:]) > 1 && sql[p:p+2] == "??": // escape ?? => ?
+			buf.WriteString(sql[:p])
+			buf.WriteString("?")
+			if len(sql[p:]) == 1 {
+				break
+			}
+			sql = sql[p+2:]
+
+		case sql[p:p+1] == "?":
+			i++
+			newArgs = append(newArgs, args[arg])
+			arg++
+			buf.WriteString(sql[:p])
+			if err := replace(buf, i); err != nil {
+				return "", nil, err
+			}
+			sql = sql[p+1:]
+
+		case len(sql[p:]) > 1 && sql[p:p+2] == "$$": // escape $$ => $
+			buf.WriteString(sql[:p])
+			buf.WriteString("$")
+			if len(sql[p:]) == 1 {
+				break
+			}
+			sql = sql[p+2:]
+
+		// If there are already some dollar placeholders, we renumber them,
+		// but make sure that if a single argument is used in multiple places we preserve that.
+		default: // $ placeholder
+			end := p + 1
+			for ; end < len(sql) && sql[end] >= '0' && sql[end] <= '9'; end++ {
+			}
+			if end == p+1 { // just a $, but not a placeholder
+				buf.WriteString(sql[:p+1])
+				sql = sql[p+1:]
+			} else {
+				num, err := strconv.Atoi(sql[p+1 : end])
+				if err != nil {
+					panic(err) // should never happen
+				}
+				j, ok := renumbered[num]
+				if !ok {
+					if renumbered == nil {
+						renumbered = make(map[int]int)
+					}
+					i++
+					renumbered[num] = i
+					j = i
+					newArgs = append(newArgs, args[arg])
+				}
+				arg++
+				buf.WriteString(sql[:p])
+				if err := replace(buf, j); err != nil {
+					return "", nil, err
+				}
+				sql = sql[end:]
+			}
+		}
+	}
+
+	buf.WriteString(sql)
+	return buf.String(), newArgs, nil
 }

--- a/placeholder_test.go
+++ b/placeholder_test.go
@@ -19,6 +19,14 @@ func TestDollar(t *testing.T) {
 	assert.Equal(t, "x = $1 AND y = $2", s)
 }
 
+func TestDollarMixed(t *testing.T) {
+	sql := "x = ? AND y = $20 AND z = $1 AND w = ? AND m = ($20, $1) AND a = ?"
+	args := []interface{}{"x", "y", "z", "w", "y", "z", "a"}
+	s, args, _ := Dollar.ReplacePlaceholdersMixed(sql, args)
+	assert.Equal(t, "x = $1 AND y = $2 AND z = $3 AND w = $4 AND m = ($2, $3) AND a = $5", s)
+	assert.Equal(t, []interface{}{"x", "y", "z", "w", "a"}, args)
+}
+
 func TestPlaceholders(t *testing.T) {
 	assert.Equal(t, Placeholders(2), "?,?")
 }
@@ -27,6 +35,10 @@ func TestEscape(t *testing.T) {
 	sql := "SELECT uuid, \"data\" #> '{tags}' AS tags FROM nodes WHERE  \"data\" -> 'tags' ??| array['?'] AND enabled = ?"
 	s, _ := Dollar.ReplacePlaceholders(sql)
 	assert.Equal(t, "SELECT uuid, \"data\" #> '{tags}' AS tags FROM nodes WHERE  \"data\" -> 'tags' ?| array['$1'] AND enabled = $2", s)
+
+	sql = "SELECT uuid, \"data\" #> '{tags}' AS tags FROM nodes WHERE  \"data\" -> 'tags' $$| array['$4'] AND enabled = $1"
+	s, _, _ = Dollar.ReplacePlaceholdersMixed(sql, []interface{}{1, 2})
+	assert.Equal(t, "SELECT uuid, \"data\" #> '{tags}' AS tags FROM nodes WHERE  \"data\" -> 'tags' $| array['$1'] AND enabled = $2", s)
 }
 
 func BenchmarkPlaceholdersArray(b *testing.B) {


### PR DESCRIPTION
While we primarily use ?, we may sometimes wish to make sure a given arg is transferred only once. That may be significant e.g. in the case of very large geometries.